### PR TITLE
Fix reinstall_2() function to find the latest version of the Paradox Launcher

### DIFF
--- a/UI_logic/MainWindow.py
+++ b/UI_logic/MainWindow.py
@@ -537,10 +537,7 @@ class MainWindow(QMainWindow, ui_main.Ui_MainWindow):
     def reinstall_2(self, paradox_folder1):
 
         launcher_folders = [item for item in os.listdir(paradox_folder1) if item.startswith("launcher")]
-        launcher_folders.sort(key=lambda x: os.path.getmtime(os.path.join(paradox_folder1, x)))
-        # launcher_folder = os.path.join(os.path.join(paradox_folder1, launcher_folders[0]))
-        launcher_folders = [item for item in os.listdir(paradox_folder1) if item.startswith("launcher")]
-        launcher_folders.sort(key=lambda x: os.path.getmtime(os.path.join(paradox_folder1, x)))
+        launcher_folders.sort(key=lambda x: os.path.getmtime(os.path.join(paradox_folder1, x)), reverse=True)
         # self.replace_files(os.path.join(os.path.join(paradox_folder1, launcher_folders[0])))
         try:
             self.replace_files(os.path.join(os.path.join(paradox_folder1, launcher_folders[0])))


### PR DESCRIPTION

The reinstall_2() function in UI_logic/MainWindow.py sorts through the list of paradox launcher versions based on the date they were created and picks the first element of that sorted list. That means that it picks the oldest version, not the newest.

This patch reverses the list so it can pick the latest added version.

Also removed duplicated code.