### PR TITLE
fix: update PyQt5-sip to match pyqt5 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5==5.15.11
-PyQt5_sip==12.15.0
+PyQt5==5.15.10
+PyQt5_sip==12.13.0
 Requests==2.32.5
 vdf==3.4


### PR DESCRIPTION
в requirements.txt была неправильна выставлена версия PyQt5_sip, из-за этого не получалось подтянуть зависимости в venv через pip install -r requirements.txt. 