### PR TITLE
Revise PowerShell quick start instructions

### DIFF
--- a/README_ZHCN.md
+++ b/README_ZHCN.md
@@ -15,11 +15,11 @@
 
 ## Windows
 
-### 🚀 快速启动 (PowerShell)
-在终端 (PowerShell) 中执行以下命令，或者按下 `Win + R` 并将代码粘贴到运行窗口中：
+### 🚀 快速启动
+在终端中运行以下命令：
 
-```powershell
-powershell -WindowStyle Hidden -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/seuyh/stellaris-dlc-unlocker/refs/heads/main/StellarisDLCUnlocker.ps1 | iex"
+```
+pwsh -WindowStyle Hidden -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/seuyh/stellaris-dlc-unlocker/refs/heads/main/StellarisDLCUnlocker.ps1 | iex"
 ```
 
 * **运行日志**：`%LocalAppData%\StellarisDLCUnlocker\unlocker.log`


### PR DESCRIPTION
Updated the quick start instructions for PowerShell to use 'pwsh' instead of 'powershell'.